### PR TITLE
main/readme: updating default CIDR block

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ module "dcos-vpc" {
 
   cluster_name = "production"
   availability_zones = ["us-east-1b"]
-  subnet_range = "172.12.0.0/16"
+  subnet_range = "172.16.0.0/16"
   # providers {
   # aws = "aws.my-provider"
   # }

--- a/main.tf
+++ b/main.tf
@@ -14,7 +14,7 @@
  *
  *   cluster_name = "production"
  *   availability_zones = ["us-east-1b"]
- *   subnet_range = "172.12.0.0/16"
+ *   subnet_range = "172.16.0.0/16"
  *   # providers {
  *   # aws = "aws.my-provider"
  *   # }


### PR DESCRIPTION
The universal installer currently is not using the correct private IP default CIDR as specified by RFC 1918.
https://tools.ietf.org/html/rfc1918

This PR is to correct this but will considered breaking change and must not be merged as a patch release but at least a minor/major version.