### PR TITLE
Give users the option to launch a cluster into an existing VPC

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,6 +17,8 @@ module "dcos-vpc" {
   # providers {
   # aws = "aws.my-provider"
   # }
+  existing_vpc_name = "my-vpc-name"
+  existing_subnet_prefix = "my-subnet-prefix"
 }
 ```
 
@@ -29,7 +31,10 @@ module "dcos-vpc" {
 | cluster_name | Name of the DC/OS cluster | string | - | yes |
 | subnet_range | Private IP space to be used in CIDR format | string | `172.31.0.0/16` | no |
 | tags | Add custom tags to all resources | map | `<map>` | no |
+| existing_vpc_name | An existing VPC to deploy into | string | - | no (if unset, new VPC will be created) |
+| existing_subnet_prefix | A prefix of existing subnets to deploy into. | string | - | no (if unset when `existing_vpc_name`, all subnets in VPC will be selected, so use with caution)
 
+Note: if deploying into existing subnets, be sure to correctly set all `*_associate_public_ip_address` addresses consistently with whether the subnet is public or private, otherwise you may not be able to reach your cluster.
 ## Outputs
 
 | Name | Description |
@@ -39,4 +44,3 @@ module "dcos-vpc" {
 | subnet_ids | List of subnet IDs created in this network |
 | subnets | List of subnet IDs created in this Network |
 | vpc_id | AWS VPC ID |
-

--- a/main.tf
+++ b/main.tf
@@ -18,6 +18,8 @@
  *   # providers {
  *   # aws = "aws.my-provider"
  *   # }
+ *   existing_vpc_name = "my-vpc-name"
+ *   existing_subnet_prefix = "my-subnet-prefix"
  * }
  *```
  */
@@ -26,9 +28,33 @@ provider "aws" {}
 // if availability zones is not set request the available in this region
 data "aws_availability_zones" "available" {}
 
-# Create a VPC to launch our instances into
+data "aws_vpc" "existing_vpc" {
+  count = "${var.existing_vpc_name == "" ? 0 : 1}"
+
+  filter {
+    "name"   = "tag:Name"
+    "values" = ["${var.existing_vpc_name}"]
+  }
+}
+
+data "aws_subnet_ids" "existing_subnet_ids" {
+  count  = "${var.existing_vpc_name == "" ? 0 : 1}"
+  vpc_id = "${join("", data.aws_vpc.existing_vpc.*.id)}"
+
+  tags {
+    "Name" = "${var.existing_subnet_prefix}*"
+  }
+}
+
+data "aws_subnet" "existing_subnets" {
+  count = "${var.existing_vpc_name == "" ? 0 : length(data.aws_subnet_ids.existing_subnet_ids.*.ids)}"
+  id    = "${data.aws_subnet_ids.existing_subnet_ids.ids[count.index]}"
+}
+
+# Create a VPC to launch our instances into, if existing vpc not set
 resource "aws_vpc" "dcos_vpc" {
-  tags = "${merge(var.tags, map("Name", var.cluster_name,
+  count = "${var.existing_vpc_name == "" ? 1 : 0}"
+  tags  = "${merge(var.tags, map("Name", var.cluster_name,
                                 "Cluster", var.cluster_name))}"
 
   cidr_block           = "${var.subnet_range}"
@@ -38,9 +64,12 @@ resource "aws_vpc" "dcos_vpc" {
 
 # Create a subnet to launch our instances into
 resource "aws_subnet" "dcos_subnet" {
-  vpc_id            = "${aws_vpc.dcos_vpc.id}"
-  count             = "${length(var.availability_zones)}"
-  cidr_block        = "${cidrsubnet(var.subnet_range, 4, count.index)}"
+  # Only create new subnets if not using an existing VPC
+  count  = "${var.existing_vpc_name == "" ? length(var.availability_zones) : 0}"
+  vpc_id = "${join("", aws_vpc.dcos_vpc.*.id)}"
+
+  cidr_block = "${cidrsubnet(join("", aws_vpc.dcos_vpc.*.cidr_block), 4, count.index)}"
+
   availability_zone = "${element(coalescelist(var.availability_zones, data.aws_availability_zones.available.names), count.index)}"
 
   map_public_ip_on_launch = true
@@ -49,9 +78,10 @@ resource "aws_subnet" "dcos_subnet" {
                                 "Cluster", var.cluster_name))}"
 }
 
-# Create an internet gateway to give our subnet access to the outside world
+# Only create an internet gateway if creating a new VPC
 resource "aws_internet_gateway" "default" {
-  vpc_id = "${aws_vpc.dcos_vpc.id}"
+  count  = "${var.existing_vpc_name == "" ? 1 : 0}"
+  vpc_id = "${join("", aws_vpc.dcos_vpc.*.id)}"
 
   tags = "${merge(var.tags, map("Name", var.cluster_name,
                                 "Cluster", var.cluster_name))}"
@@ -59,7 +89,10 @@ resource "aws_internet_gateway" "default" {
 
 # Grant the VPC internet access on its main route table
 resource "aws_route" "internet_access" {
-  route_table_id         = "${aws_vpc.dcos_vpc.main_route_table_id}"
+  count = "${var.existing_vpc_name == "" ? 1 : 0}"
+
+  route_table_id = "${join("", aws_vpc.dcos_vpc.*.main_route_table_id)}"
+
   destination_cidr_block = "0.0.0.0/0"
   gateway_id             = "${aws_internet_gateway.default.id}"
 }

--- a/outputs.tf
+++ b/outputs.tf
@@ -19,10 +19,10 @@ output "aws_main_route_table_id" {
 output "subnet_ids" {
   description = "List of subnet IDs created in this network"
 
-  value = "${length(var.existing_vpc_name) == 0 ?
-    join("", aws_subnet.dcos_subnet.*.id) :
-    join("", data.aws_subnet_ids.existing_subnet_ids.*.id)
-  }"
+  value = "${split(",", length(var.existing_vpc_name) == 0 ?
+    join(",", aws_subnet.dcos_subnet.*.id) :
+    join(",", flatten(data.aws_subnet_ids.existing_subnet_ids.*.ids))
+  )}"
 }
 
 output "vpc_id" {

--- a/outputs.tf
+++ b/outputs.tf
@@ -1,24 +1,35 @@
 output "cidr_block" {
   description = "Output the cidr_block used within this network"
-  value       = "${aws_vpc.dcos_vpc.cidr_block}"
+
+  value = "${length(var.existing_vpc_name) == 0 ?
+    join("", aws_vpc.dcos_vpc.*.cidr_block) :
+    join("", data.aws_vpc.existing_vpc.*.cidr_block)
+  }"
 }
 
 output "aws_main_route_table_id" {
   description = "AWS main route table id"
-  value       = "${aws_vpc.dcos_vpc.main_route_table_id}"
+
+  value = "${length(var.existing_vpc_name) == 0 ?
+    join("", aws_vpc.dcos_vpc.*.main_route_table_id) :
+    join("", data.aws_vpc.existing_vpc.*.main_route_table_id)
+  }"
 }
 
 output "subnet_ids" {
   description = "List of subnet IDs created in this network"
-  value       = ["${aws_subnet.dcos_subnet.*.id}"]
-}
 
-output "subnets" {
-  description = "List of subnet IDs created in this Network"
-  value       = ["${aws_subnet.dcos_subnet.*.id}"]
+  value = "${length(var.existing_vpc_name) == 0 ?
+    join("", aws_subnet.dcos_subnet.*.id) :
+    join("", data.aws_subnet_ids.existing_subnet_ids.*.id)
+  }"
 }
 
 output "vpc_id" {
   description = "AWS VPC ID"
-  value       = "${aws_vpc.dcos_vpc.id}"
+
+  value = "${length(var.existing_vpc_name) == 0 ?
+    join("", aws_vpc.dcos_vpc.*.id) :
+    join("", data.aws_vpc.existing_vpc.*.id)
+  }"
 }

--- a/variables.tf
+++ b/variables.tf
@@ -18,3 +18,13 @@ variable "tags" {
   type        = "map"
   default     = {}
 }
+
+variable "existing_vpc_name" {
+  description = "Name of an existing VPC to deploy into"
+  default     = ""
+}
+
+variable "existing_subnet_prefix" {
+  description = "Prefix of existing VPC subnets to use"
+  default     = ""
+}


### PR DESCRIPTION
If launching into an existing VPC, they can choose existing subnets by prefix (default to all)
Can also optionally choose to create an internet gateway and route, which may conflict with existing resources
All variables are completely optional - if not specified, plan output is the same as without this change